### PR TITLE
Dicke blk

### DIFF
--- a/src/Eff_QFI_HD_Dicke.jl
+++ b/src/Eff_QFI_HD_Dicke.jl
@@ -145,6 +145,14 @@ function Eff_QFI_HD_Dicke(Nj::Int64, # Number of spins
         tmp1 = similar(ρ0)
         tmp2 = similar(ρ0)
 
+        # Temporary operator in order to allocate Mpre
+        # and Mpost
+        Mtmp = (M0 + sqrt(η * κcoll) * Jy * 1. +
+                    η * (κcoll/2) * Jy2 * (1. ^2 - dt))
+
+        Mpre = sup_pre(Mtmp)
+        Mpost = sup_post(Mtmp)
+
         # Output variables
         jx = similar(t)
         jy = similar(t)
@@ -172,8 +180,8 @@ function Eff_QFI_HD_Dicke(Nj::Int64, # Number of spins
             end
 
             @timeit_debug to "sup_creation" begin
-                Mpre = sup_pre(M)
-                Mpost = sup_post(M)
+                @timeit_debug to "pre" fast_sup_pre!(Mpre, M)
+                @timeit_debug to "post" fast_sup_post!(Mpost, M)
             end
 
             #@info "Eigvals" eigvals(Hermitian(Matrix(reshape(ρ, size(Jx)))))[1]
@@ -252,7 +260,6 @@ function Eff_QFI_HD_Dicke(Nj::Int64, # Number of spins
         # if traj_count % 10 == 0
         #     @info "$(traj_count) trajectories done"
         # end
-
         # Use the reduction feature of @distributed for
         # (at the end of each cicle, sum the result to result)
         hcat(FisherT, QFisherT, jx, jy, jz, Δjx2, Δjy2, Δjz2, xi2x, xi2y, xi2z)

--- a/src/NoiseOperators.jl
+++ b/src/NoiseOperators.jl
@@ -3,6 +3,8 @@ Functions for constructing noise operators
 =#
 using SparseArrays
 using LinearAlgebra
+import SparseArrays.getcolptr
+
 """
     σ_j(j, n, direction)
 
@@ -74,6 +76,7 @@ function sup_pre(A)
     return blkdiag(A, size(A, 1))
 end
 
+
 """
     sup_post(A)
 
@@ -129,4 +132,53 @@ function blkdiag(X::SparseMatrixCSC{Tv, Ti}, num) where {Tv, Ti<:Integer}
     end
     colptr[n+1] = num * nnzX + 1
     SparseMatrixCSC(m, n, colptr, rowval, nzval)
+end
+
+# function blkdiag!(Sup::SparseMatrixCSC{Tv, Ti}, X::SparseMatrixCSC{Tv, Ti}, num) where {Tv, Ti<:Integer}
+#     copy!(Sup.nzval, repeat(X.nzval, num))
+#     return Sup
+# end
+
+"""
+Non-allocating update of the matrix Sup = I ⊗ A.
+
+ATTENTION!!! It assumes the position of the non-zero elements
+does not change!
+USE WITH CARE!!!!!
+"""
+function fast_sup_pre!(Sup::SparseMatrixCSC{Tv, Ti}, A::SparseMatrixCSC{Tv, Ti}) where {Tv, Ti<:Integer}
+    num = size(A, 1)
+    nnzX = nnz(A)
+    @inbounds @simd for i = 1 : num
+         @simd for j = 1 : nnzX
+            Sup.nzval[(i - 1) * nnzX + j] = A.nzval[j]
+        end
+    end
+end
+
+"""
+Non-allocating update of the matrix Sup = A' ⊗ I.
+
+ATTENTION!!! It assumes the position of the non-zero elements
+does not change!
+USE WITH CARE!!!!!
+"""
+function fast_sup_post!(Sup::SparseMatrixCSC{T1, S1}, A::SparseMatrixCSC{T1,S1}) where {T1, S1}
+    n = size(A, 1)
+    col = 1
+
+    @inbounds for j = 1 : n
+        startA = getcolptr(A)[j]
+        stopA = getcolptr(A)[j+1] - 1
+        lA = stopA - startA + 1
+        for i = 1:n
+            ptr_range = Sup.colptr[col]
+            col += 1
+            for ptrA = startA : stopA
+                Sup.nzval[ptr_range] = nonzeros(A)[ptrA]'
+                ptr_range += 1
+            end
+        end
+    end
+    return Sup
 end

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -9,12 +9,12 @@ include("../src/NoiseOperators.jl")
 end
 
 @testset "Spre, spost" begin
-N = 4
-ρ = rand(N, N) + 1im * rand(N,N)
-A = rand(N, N) + 1im * rand(N,N)
+N = 10
+# ρ = rand(N, N) + 1im * rand(N,N)
+# A = rand(N, N) + 1im * rand(N,N)
 
-@test ρ * A' ≈ reshape(sup_post(A) * ρ[:], (N,N))
-@test A * ρ ≈ reshape(sup_pre(A) * ρ[:], (N,N))
+# @test ρ * A' ≈ reshape(sup_post(A) * ρ[:], (N,N))
+# @test A * ρ ≈ reshape(sup_pre(A) * ρ[:], (N,N))
 
 ρ = sprand(N, N, .1) + 1im *  sprand(N, N, .1)
 A = sprand(N, N, .1) + 1im * sprand(N, N, .1)
@@ -26,8 +26,8 @@ A = sprand(N, N, .1) + 1im * sprand(N, N, .1)
 @test typeof(sup_pre(A)) <: typeof(A)
 
 ρ = rand(N, N) + 1im * rand(N,N)
-A = rand(N, N) + 1im * rand(N,N)
-B = rand(N, N) + 1im * rand(N,N)
+A = sprand(N, N, .3) + 1im * sprand(N,N, .3)
+B = sprand(N, N, .3) + 1im * sprand(N,N, .3)
 
 @test A * ρ * B' ≈ reshape(sup_pre(A) * sup_post(B) * ρ[:], (N,N))
 @test A * ρ * B' ≈ reshape(sup_post(B) * sup_pre(A) * ρ[:], (N,N))


### PR DESCRIPTION
Added `fast_sup_pre!` and `fast_sup_post!` functions. They assume that the sparsity pattern of the superoperator is the same as the target sparse matrix and they simply overwrite the values (use with caution!).

Also reduced allocations in dynamics.