### PR TITLE
Evaluate QFI blockwise

### DIFF
--- a/src/Eff_QFI_HD_Dicke.jl
+++ b/src/Eff_QFI_HD_Dicke.jl
@@ -222,6 +222,7 @@ function Eff_QFI_HD_Dicke(Nj::Int64, # Number of spins
                 # Now we can renormalize ρ and its derivative wrt ω
                 ρ .= new_ρ ./ tr_ρ
                 dρ .= τ .- tr_τ .* ρ
+
             end
 
             if jt % outsteps == 0
@@ -238,11 +239,12 @@ function Eff_QFI_HD_Dicke(Nj::Int64, # Number of spins
                     FisherT[jto] = real(tr_τ^2)
 
                     # We evaluate the QFI for a final strong measurement done at time t
-                    @timeit_debug to "QFI" QFisherT[jto] = QFI(reshape(ρ, size(Jy)), reshape(dρ, size(Jy)))
+                    @timeit_debug to "QFI" QFisherT[jto] = QFI_block(reshape(ρ, size(Jy)), reshape(dρ, size(Jy)), Nj)
 
                     jto += 1
                 end
             end
+
         end
 
         Δjx2 = jx2 - jx.^2

--- a/src/Fisher.jl
+++ b/src/Fisher.jl
@@ -1,4 +1,5 @@
 using ZChop
+
 """
     QFI(ρ, dρ [, abstol])
 
@@ -32,4 +33,30 @@ function QFI(ρ, dρ; abstol = 1e-5)
         end
     end
     return res
+end
+
+"""
+    QFI_block(ρ, dρ, N [, abstol])
+
+Numerically evaluate the quantum Fisher information for the matrix ρ given its derivative dρ wrt the parameter,
+for the special case of a block-diagonal matrix in the Dicke basis.
+
+This function is the implementation of Eq. (13) in Paris, Int. J. Quantum Inform. 7, 125 (2009).
+
+# Arguments
+    * `ρ`:  Density matrix
+    * `dhro`: Derivative wrt the parameter to be estimated
+    * `N`: number of spins
+    * `abstol = 1e-5`: tolerance in the denominator of the formula
+"""
+function QFI_block(ρ, dρ, N; abstol = 1e-5)
+    blockidx = cumsum(block_sizes(N))
+    qfi = 0.
+    lastidx = 1
+    for i = 1:length(blockidx)
+        idx_range = lastidx:blockidx[i]
+        qfi += QFI(view(ρ, idx_range, idx_range), view(dρ, idx_range, idx_range))
+        lastidx = blockidx[i] + 1
+    end
+    return qfi
 end

--- a/src/piqs.jl
+++ b/src/piqs.jl
@@ -3,8 +3,8 @@ using SparseArrays
 """
     tosparse(obj)
 
-Returns the sparse matrix corresponding to the PyObject obj. 
-obj can be a scipy.sparse matrix or a qutip Qobj 
+Returns the sparse matrix corresponding to the PyObject obj.
+obj can be a scipy.sparse matrix or a qutip Qobj
 """
 function tosparse(obj::PyObject)
     # This is just a wrapper to the ugly py"..." syntax
@@ -12,6 +12,44 @@ function tosparse(obj::PyObject)
     return sparse(I, J, V, m, n)
 end
 
-function css(N)
+"""
+    css(N)
+
+Return a coherent spin state in the Dicke basis for N spins
+"""
+function css(N::T) where T<:Integer
     return tosparse(piqs.css(N))
+end
+
+"""
+    j_min(N)
+
+Return the minimum value of j for N spins
+"""
+function j_min(N::T) where T<:Integer
+    if N % 2 == 0
+        return 0
+    else
+        return 0.5
+    end
+end
+
+"""
+    j_vals(N)
+
+Returns a list of values of j in decreasing order
+"""
+function j_vals(N::T) where T<:Integer
+    j = (N/2):-1:j_min(N)
+    return j
+end
+
+"""
+    block_sizes(N)
+
+Return a list of block sizes for the density matrix of a N-spin
+system in the Dicke basis.
+"""
+function block_sizes(N::T) where T<:Integer
+   return Int.(2*j_vals(N) .+ 1)
 end


### PR DESCRIPTION
Since rho and drho are block-diagonal, the QFI is now calculated block by block for faster execution and smaller memory allocation.