### PR TITLE
Use sparse rho

### DIFF
--- a/src/Eff_QFI_HD_Dicke.jl
+++ b/src/Eff_QFI_HD_Dicke.jl
@@ -87,7 +87,7 @@ function Eff_QFI_HD_Dicke(Nj::Int64, # Number of spins
         Jz2 = Jz^2
 
         @info "Type of ρ: $(typeof(ρ0))"
-        @info "Size of ρ: $(length(ρ0))"
+        @info "Size of ρ: $(length(ρ0)), $(length(ρ0.nzval)) non-zero elements"
         @info "Density of noise superoperator: $(density(indprepost))"
 
         @timeit_debug to "op_creation" begin

--- a/src/Eff_QFI_HD_Dicke.jl
+++ b/src/Eff_QFI_HD_Dicke.jl
@@ -79,13 +79,14 @@ function Eff_QFI_HD_Dicke(Nj::Int64, # Number of spins
 
             # Initial state of the system
             # is a spin coherent state |++...++>
-            ρ0 = Matrix(css(Nj))[:]
+            ρ0 = css(Nj)[:]
         end
 
         Jx2 = Jx^2
         Jy2 = Jy^2
         Jz2 = Jz^2
 
+        @info "Type of ρ: $(typeof(ρ0))"
         @info "Size of ρ: $(length(ρ0))"
         @info "Density of noise superoperator: $(density(indprepost))"
 


### PR DESCRIPTION
Threat the density matrix as sparse. In the dicke basis, rho has a block diagonal structure with O(N^3) non-zero elements, as opposed to O(N^4) size. We make use of that and gain some speed for N > 50.